### PR TITLE
Created commit_policy_pt.md

### DIFF
--- a/docs/templates/commit_policy.md
+++ b/docs/templates/commit_policy.md
@@ -4,7 +4,7 @@
 Share work development in small and concise *commits*, so that each commit implements one feature.
 
 ### *Commits* in English
-The commmits' messages pattern must be done in **English**, in order to make the project more accessible to the global public. 
+The commits' messages pattern must be done in **English**, in order to make the project more accessible to the global public. 
 
 ### Rule 50/72
 The messages must contain maximum 50 characters. If a better message is needed, add a new blank line and describe better the commit using the amount of lines necessary.
@@ -29,7 +29,7 @@ The anatomy of the commit must follow this following pattern:
 -   Maximum 50 characters.
 -   Scope type must be lowercase. 
 
-Exemple:
+Example:
 
 `fix(#13): route correction /login`.
 
@@ -44,14 +44,15 @@ The values allowed for `type`  are:
 
 ### Body
 
-If it's necessary to give a context to the commit and explain the reasons of the changes, writte in the commit's body following the rule:
+If it's necessary to give a context to the commit and explain the reasons of the changes, write in the commit's body following the rule:
 
 -   Must contain the reason of the change and what was changed.
 -   Maximum of 72 characters per line.
 
-Exemple:
+Example:
 
 ```
-refactor(#28): change in registration button 
+refact(#28): change in registration button 
 
 The button was not intuitive
+```

--- a/docs/templates/commit_policy_pt.md
+++ b/docs/templates/commit_policy_pt.md
@@ -1,0 +1,56 @@
+# Politica de Commits
+
+### *Commits* Atômicos
+Compartilhe o desenvolvimento em pequenos e concisos *commits*, assim cada *commit* implementa uma funcionalidade.
+
+### *Commits* em inglês
+Os padrões de mensagens dos *commits* devem ser feitos em **Inglês** para que o projeto seja mais acessível ao público global.
+
+### Regra 50/70
+As mensagens devem conter no máximo 50 caracteres. Caso uma mensagem mais elaborada seja necessária, adicione uma nova linha em branco e descreva melhor o *commit* usando a quantidade de linhas necessária.
+Entretanto, cada linha deve respeitar o número máximo de 72 caracteres. Se seu *commit* precisar de mais espaço, ele não é atômico.
+
+
+# Anatomia do *Commit*
+A anatomia do commit deve seguir os seguintes padrões:
+
+### Formato:
+```
+<tipo>(#número da issue): assunto
+
+<corpo>
+...
+```
+
+
+
+### Assunto
+
+- Máximo de 50 caracteres
+- Tipo do escopo deve ser em letra minúscula
+
+Exemplo:
+
+`fix(#13): route correction /login`
+
+Os valores permitidos para `type` são:
+-   `feat`: nova funcionalidade
+-   `style`: formatação genérica no código
+-   `refact`: reestruturação do código
+-   `test`: correções
+-   `docs`: relacionado a documentação
+
+### Corpo
+
+Caso seja necessário dar contexto ao *commit* e explicar as razões das mudanças, escreva no corpo do *commit* conforme as seguintes regras:
+
+-   Deve conter a razão da mudança e o que foi modificado.
+-   Máximo de 72 caracteres por linha.
+
+Exemplo:
+
+```
+refact(#28): change in registration button
+
+The button was not intuitive
+```


### PR DESCRIPTION
### Descrição - Tradução da commit policy
Criado arquivo commit_policy_pt.md com a tradução do commit_policy.md e foram feitas alterações em erros de digitação da commit_policy.md


### Porque este Pull Request é necessário?
Orientar contribuidores do projeto.

### Critérios de Aceitação
#### Checklist

- [x] Arquivo commit_policy_pt.md estar nos padrões.


Resolve #38
